### PR TITLE
Add exception handling and package version listing

### DIFF
--- a/bin/pub_server.dart
+++ b/bin/pub_server.dart
@@ -11,7 +11,7 @@ Future<void> main(List<String> arguments) async {
   final router = Router();
 
   // TODO: Remove this once actual DB is implemented
-  final fakedb = FakeDatabase();
+  final fakedb = FakeDatabase.instance;
 
   router.mount('/api/packages/', FetchPackages(fakedb).router);
 

--- a/bin/pub_server.dart
+++ b/bin/pub_server.dart
@@ -1,6 +1,5 @@
-import 'dart:io';
-
 import 'package:pub_server/pub_server.dart';
+import 'package:pub_server/src/fake/fake_database.dart';
 import 'package:shelf/shelf.dart';
 import 'package:shelf/shelf_io.dart' as io;
 import 'package:shelf_router/shelf_router.dart';
@@ -11,6 +10,7 @@ const PORT_NO = 8080;
 Future<void> main(List<String> arguments) async {
   final router = Router();
 
+  // TODO: Remove this once actual DB is implemented
   final fakedb = FakeDatabase();
 
   router.mount('/api/packages/', FetchPackages(fakedb).router);
@@ -23,24 +23,4 @@ Future<void> main(List<String> arguments) async {
 
   final server = await io.serve(handler, PUB_HOSTED_URL, PORT_NO);
   print('Connected on http://${server.address.host}:${server.port}');
-}
-
-class FakeDatabase extends Database {
-  @override
-  Future<ListVersionModel> listPackageVersion(String package) async {
-    final data = await _readFile('list_package.json');
-    return ListVersionModel.fromJson(data);
-  }
-
-  @override
-  Future<VersionModel> packageVersion(String package, String version) async {
-    final data = await _readFile('list_package.json');
-    return VersionModel.fromJson(data);
-  }
-
-  Future<String> _readFile(String name) async {
-    final fileAddress = await File('fake_data/$name').resolveSymbolicLinks();
-    final file = File(fileAddress);
-    return file.readAsString();
-  }
 }

--- a/lib/src/database.dart
+++ b/lib/src/database.dart
@@ -1,7 +1,8 @@
-import 'package:pub_server/src/models/list_version_model.dart';
-import 'package:pub_server/src/models/version_model.dart';
+import 'models/list_version_model.dart';
+import 'models/version_model.dart';
 
 abstract class Database {
   Future<ListVersionModel> listPackageVersion(String package);
+
   Future<VersionModel> packageVersion(String package, String version);
 }

--- a/lib/src/exceptions.dart
+++ b/lib/src/exceptions.dart
@@ -81,6 +81,10 @@ class InvalidInputException extends ResponseException {
     }
   }
 
+  static void checkNotEmpty(dynamic value, String name) {
+    _check(value.toString().isNotEmpty, () => '"$name" cannot be empty');
+  }
+
   /// Throw [InvalidInputException] if [value] is not `null`.
   static void checkNull(dynamic value, String name) {
     _check(value == null, () => '"$name" must be `null`');

--- a/lib/src/exceptions.dart
+++ b/lib/src/exceptions.dart
@@ -1,0 +1,168 @@
+import 'dart:convert';
+
+import 'package:pub_semver/pub_semver.dart';
+import 'package:shelf/shelf.dart';
+
+class ApiResponseException implements Exception {
+  final int status;
+  final String code;
+  final String message;
+
+  ApiResponseException({
+    required this.status,
+    required this.code,
+    required this.message,
+  });
+
+  Response asApiResponse() => Response(status,
+          body: json.fuse(utf8).encode({
+            'error': {
+              'code': code,
+              'message': message,
+            },
+          }),
+          headers: {
+            'content-type': 'application/json; charset="utf-8"',
+            'x-content-type-options': 'nosniff',
+          });
+}
+
+/// Base class for all exceptions that are intercepted by HTTP handler wrappers.
+abstract class ResponseException extends ApiResponseException {
+  ResponseException._(int status, String code, String message)
+      : super(status: status, code: code, message: message);
+
+  @override
+  String toString() => '$code($status): $message'; // implemented for debugging
+}
+
+/// Thrown when resource does not exist.
+class NotFoundException extends ResponseException {
+  NotFoundException(String message) : super._(404, 'NotFound', message);
+  NotFoundException.resource(String resource)
+      : super._(404, 'NotFound', 'Could not find `$resource`.');
+}
+
+/// Thrown when request is not acceptable.
+class NotAcceptableException extends ResponseException {
+  NotAcceptableException(String message)
+      : super._(406, 'NotAcceptable', message);
+}
+
+/// Thrown when request input is invalid, bad payload, wrong querystring, etc.
+class InvalidInputException extends ResponseException {
+  InvalidInputException._(String message)
+      : super._(
+          400,
+          'InvalidInput', // also duplicated in api_builder.dart
+          message,
+        );
+
+  /// Thrown when the parsing and/or validating of the continuation token failed.
+  InvalidInputException.continuationParseError()
+      : this._('Parsing the continuation token failed.');
+
+  /// Thrown when the canonicalization of the [version] failed.
+  InvalidInputException.canonicalizeVersionError(String version)
+      : this._('Unable to canonicalize the version: $version');
+
+  /// Check [condition] and throw [InvalidInputException] with [message] if
+  /// [condition] is `false`.
+  static void check(bool condition, String message) {
+    if (!condition) {
+      throw InvalidInputException._(message);
+    }
+  }
+
+  /// A variant of [check] with lazy message construction.
+  static void _check(bool condition, String Function() message) {
+    if (!condition) {
+      throw InvalidInputException._(message());
+    }
+  }
+
+  /// Throw [InvalidInputException] if [value] is not `null`.
+  static void checkNull(dynamic value, String name) {
+    _check(value == null, () => '"$name" must be `null`');
+  }
+
+  /// Throw [InvalidInputException] if [value] is `null`.
+  static void checkNotNull(dynamic value, String name) {
+    _check(value != null, () => '"$name" cannot be `null`');
+  }
+
+  /// Throw [InvalidInputException] if [value] doesn't match [regExp].
+  static void checkMatchPattern(String value, String name, RegExp regExp) {
+    _check(regExp.hasMatch(value), () => '"$name" must match $regExp');
+  }
+
+  /// Throw [InvalidInputException] if [value] is not one of [values].
+  static void checkAnyOf<T>(T value, String name, Iterable<T> values) {
+    _check(values.contains(value),
+        () => '"$name" must be any of ${values.join(', ')}');
+  }
+
+  /// Throw [InvalidInputException] if [value] is less than [minimum] or greater
+  /// than [maximum].
+  static void checkRange<T extends num>(
+    T? value,
+    String name, {
+    T? minimum,
+    T? maximum,
+  }) {
+    _check(value != null, () => '"$name" cannot be `null`');
+    _check((minimum == null || (value != null && value >= minimum)),
+        () => '"$name" must be greater than $minimum');
+    _check((maximum == null || (value != null && value <= maximum)),
+        () => '"$name" must be less than $maximum');
+  }
+
+  /// Throw [InvalidInputException] if [value] is shorter than [minimum] or
+  /// longer than [maximum].
+  ///
+  /// This also throws if [value] is `null`.
+  static void checkStringLength(
+    String? value,
+    String name, {
+    int? minimum,
+    int? maximum,
+  }) {
+    _check(value != null, () => '"$name" cannot be `null`');
+    _check((minimum == null || (value != null && value.length >= minimum)),
+        () => '"$name" must be longer than $minimum charaters');
+    _check((maximum == null || (value != null && value.length <= maximum)),
+        () => '"$name" must be less than $maximum charaters');
+  }
+
+  /// Throw [InvalidInputException] if [value] is shorter than [minimum] or
+  /// longer than [maximum].
+  static void checkLength<T>(
+    Iterable<T>? value,
+    String name, {
+    int? minimum,
+    int? maximum,
+  }) {
+    _check(value != null, () => '"$name" cannot be `null`');
+    final length = value!.length;
+    _check((minimum == null || length >= minimum),
+        () => '"$name" must be longer than $minimum');
+    _check((maximum == null || length <= maximum),
+        () => '"$name" must be less than $maximum');
+  }
+
+  static final _ulidPattern = RegExp(r'^[a-zA-Z0-9]*$');
+
+  static void checkUlid(String value, String name) {
+    _check(_ulidPattern.hasMatch(value), () => '"$name" is not a valid ulid.');
+  }
+
+  static void checkSemanticVersion(String version) {
+    checkNotNull(version, 'version');
+    try {
+      Version.parse(version);
+    } on FormatException catch (_) {
+      throw InvalidInputException._(
+          'Version string "$version" is not a valid semantic version.');
+    }
+  }
+}

--- a/lib/src/fake/fake_database.dart
+++ b/lib/src/fake/fake_database.dart
@@ -1,0 +1,24 @@
+import 'dart:io';
+
+import '../../pub_server.dart';
+
+// TODO: Move this to test once actual DB is implemented
+class FakeDatabase extends Database {
+  @override
+  Future<ListVersionModel> listPackageVersion(String package) async {
+    final data = await _readFile('list_package.json');
+    return ListVersionModel.fromJson(data);
+  }
+
+  @override
+  Future<VersionModel> packageVersion(String package, String version) async {
+    final data = await _readFile('list_package.json');
+    return VersionModel.fromJson(data);
+  }
+
+  Future<String> _readFile(String name) async {
+    final fileAddress = await File('fake_data/$name').resolveSymbolicLinks();
+    final file = File(fileAddress);
+    return file.readAsString();
+  }
+}

--- a/lib/src/fake/fake_database.dart
+++ b/lib/src/fake/fake_database.dart
@@ -1,11 +1,15 @@
 import 'dart:io';
 
 import '../../pub_server.dart';
+import '../exceptions.dart';
 
 // TODO: Move this to test once actual DB is implemented
 class FakeDatabase extends Database {
   @override
   Future<ListVersionModel> listPackageVersion(String package) async {
+    if (package != 'fake_package') {
+      throw NotFoundException('$package was not found');
+    }
     final data = await _readFile('list_package.json');
     return ListVersionModel.fromJson(data);
   }

--- a/lib/src/fake/fake_database.dart
+++ b/lib/src/fake/fake_database.dart
@@ -5,6 +5,14 @@ import '../exceptions.dart';
 
 // TODO: Move this to test once actual DB is implemented
 class FakeDatabase extends Database {
+  static FakeDatabase? _instance;
+  FakeDatabase._();
+
+  static FakeDatabase get instance {
+    _instance ??= FakeDatabase._();
+    return _instance!;
+  }
+
   @override
   Future<ListVersionModel> listPackageVersion(String package) async {
     if (package != 'fake_package') {

--- a/lib/src/models/list_version_model.dart
+++ b/lib/src/models/list_version_model.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 
 import 'package:collection/collection.dart';
 
-import 'package:pub_server/src/models/version_model.dart';
+import 'version_model.dart';
 
 class ListVersionModel {
   final String name;
@@ -47,7 +47,7 @@ class ListVersionModel {
     );
   }
 
-  String toJson() => json.encode(toMap());
+  List<int> toJson() => json.fuse(utf8).encode(toMap());
 
   factory ListVersionModel.fromJson(String source) =>
       ListVersionModel.fromMap(json.decode(source));

--- a/lib/src/models/version_model.dart
+++ b/lib/src/models/version_model.dart
@@ -41,7 +41,7 @@ class VersionModel {
     );
   }
 
-  String toJson() => json.encode(toMap());
+  List<int> toJson() => json.fuse(utf8).encode(toMap());
 
   factory VersionModel.fromJson(String source) =>
       VersionModel.fromMap(json.decode(source));

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -149,7 +149,7 @@ packages:
     source: hosted
     version: "0.12.10"
   meta:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: meta
       url: "https://pub.dartlang.org"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -198,7 +198,7 @@ packages:
     source: hosted
     version: "1.5.0"
   pub_semver:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: pub_semver
       url: "https://pub.dartlang.org"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -92,6 +92,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.1"
+  http:
+    dependency: "direct dev"
+    description:
+      name: http
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.13.3"
   http_methods:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,5 +10,6 @@ dependencies:
   shelf_router: ^1.0.0
 
 dev_dependencies:
+  http: ^0.13.3
   pedantic: ^1.11.0
   test: ^1.16.8

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,6 +6,7 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
+  meta: ^1.3.0
   pub_semver: ^2.0.0
   shelf: ^1.1.0
   shelf_router: ^1.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,6 +6,7 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
+  pub_semver: ^2.0.0
   shelf: ^1.1.0
   shelf_router: ^1.0.0
 

--- a/test/constants.dart
+++ b/test/constants.dart
@@ -1,0 +1,2 @@
+const PUB_HOSTED_URL = 'localhost';
+const PORT_NO = 8080;

--- a/test/pub_server_test.dart
+++ b/test/pub_server_test.dart
@@ -1,4 +1,1 @@
-import 'package:pub_server/pub_server.dart';
-import 'package:test/test.dart';
-
 void main() {}

--- a/test/src/fetch_package_test.dart
+++ b/test/src/fetch_package_test.dart
@@ -20,7 +20,7 @@ void main() {
   setUp(() async {
     final router = Router();
 
-    final fakedb = FakeDatabase();
+    final fakedb = FakeDatabase.instance;
 
     router.mount('$_path/', FetchPackages(fakedb).router);
 

--- a/test/src/fetch_package_test.dart
+++ b/test/src/fetch_package_test.dart
@@ -14,7 +14,7 @@ void main() {
   late http.Client client;
   late Uri uri;
 
-  const _path = '/api/packages/';
+  const _path = '/api/packages';
   const _packageName = 'fake_package';
 
   setUp(() async {
@@ -22,26 +22,32 @@ void main() {
 
     final fakedb = FakeDatabase();
 
-    router.mount(_path, FetchPackages(fakedb).router);
+    router.mount('$_path/', FetchPackages(fakedb).router);
 
     server = await io.serve(router, PUB_HOSTED_URL, PORT_NO);
-    uri = Uri.parse('https://${server.address.host}:${server.port}');
+    uri = Uri.parse('http://${server.address.host}:${server.port}');
 
     client = http.Client();
   });
 
-  // tearDown(() async {
-  //   await server.close();
-  //   client.close();
-  // });
+  tearDown(() async {
+    await server.close();
+    client.close();
+  });
 
   group('Fetch packages end-points', () {
     test('get list of all versions of a package', () async {
-      final result = await client.get(uri.replace(path: '$_path$_packageName'));
-      expect(200, result.statusCode);
+      final result =
+          await client.get(uri.replace(path: '$_path/$_packageName'));
+      expect(result.statusCode, 200);
 
       final listVersionModel = ListVersionModel.fromJson(result.body);
       expect('fake_package', equals(listVersionModel.name));
+    });
+
+    test('throws 404 if package not found', () async {
+      final result = await client.get(uri.replace(path: '$_path/not_found'));
+      expect(result.statusCode, 404);
     });
   });
 }

--- a/test/src/fetch_package_test.dart
+++ b/test/src/fetch_package_test.dart
@@ -1,0 +1,47 @@
+import 'dart:io';
+
+import 'package:pub_server/pub_server.dart';
+import 'package:pub_server/src/fake/fake_database.dart';
+import 'package:shelf_router/shelf_router.dart';
+import 'package:test/test.dart';
+import 'package:shelf/shelf_io.dart' as io;
+import 'package:http/http.dart' as http;
+
+import '../constants.dart';
+
+void main() {
+  late HttpServer server;
+  late http.Client client;
+  late Uri uri;
+
+  const _path = '/api/packages/';
+  const _packageName = 'fake_package';
+
+  setUp(() async {
+    final router = Router();
+
+    final fakedb = FakeDatabase();
+
+    router.mount(_path, FetchPackages(fakedb).router);
+
+    server = await io.serve(router, PUB_HOSTED_URL, PORT_NO);
+    uri = Uri.parse('https://${server.address.host}:${server.port}');
+
+    client = http.Client();
+  });
+
+  // tearDown(() async {
+  //   await server.close();
+  //   client.close();
+  // });
+
+  group('Fetch packages end-points', () {
+    test('get list of all versions of a package', () async {
+      final result = await client.get(uri.replace(path: '$_path$_packageName'));
+      expect(200, result.statusCode);
+
+      final listVersionModel = ListVersionModel.fromJson(result.body);
+      expect('fake_package', equals(listVersionModel.name));
+    });
+  });
+}


### PR DESCRIPTION
Going forward we can throw Exceptions from `ApiResponseException` class and we should wrap all the method calls into a try-catch to make this conversion happen.

closes #1, #5